### PR TITLE
if missing an entity due to overlapping, find the first entity of the given type and regression test.

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder/Luis/Extensions.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder/Luis/Extensions.cs
@@ -63,6 +63,12 @@ namespace Microsoft.Bot.Builder.Luis
 
             // find the recommended entity that does not overlap start and end ranges with other result entities
             entity = result.Entities?.Where(e => e.Type == type && doesNotOverlapRange(e, result.Entities)).FirstOrDefault();
+            
+            //if missing a non overlapping entity, find the first entity of the given type
+            if (entity == null)
+            {
+                entity = result.Entities?.FirstOrDefault(e => e.Type == type);
+            }
             return entity != null;
         }
 

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/LuisTryFindEntityTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/LuisTryFindEntityTests.cs
@@ -62,35 +62,6 @@ namespace Microsoft.Bot.Builder.Tests
         }
 
         [TestMethod]
-        public void Luis_TryFindEntity_Date_And_One_Number_Where_One_Number_Overlaps()
-        {
-            // assemble
-
-            var recommendations = new List<EntityRecommendation>
-            {
-                new EntityRecommendation { Type = "builtin.number", Entity = "10", StartIndex=25, EndIndex=27}, // it should not consider this a number since if overlaps with the datetime entity
-                new EntityRecommendation { Type = "builtin.datetimeV2.time", Entity = "10 pm", StartIndex=25, EndIndex=30}
-            };
-
-            var result = new LuisResult("make me a reservation at 10 pm", recommendations);
-
-            // act
-
-            EntityRecommendation numberRecommendation;
-            result.TryFindEntity("builtin.number", out numberRecommendation);
-
-            EntityRecommendation timeRecommendation;
-            result.TryFindEntity("builtin.datetimeV2.time", out timeRecommendation);
-
-
-            // assert
-
-            Assert.IsNotNull(timeRecommendation, "time entity recommendation not found");
-            Assert.IsNull(numberRecommendation, "number recommendation should be null as it falls within the datetime range");
-            Assert.AreEqual("10 pm", timeRecommendation.Entity, "wrong entity recommendation selected");
-        }
-
-        [TestMethod]
         public void Luis_TryFindEntity_Find_Number_No_Overlaps()
         {
             // assemble

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/LuisTryFindEntityTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/LuisTryFindEntityTests.cs
@@ -8,6 +8,33 @@ namespace Microsoft.Bot.Builder.Tests
     [TestClass]
     public class LuisTryFindEntityTests
     {
+        [TestMethod]
+        public void Luis_TryFindEntity_Foo_Where_Built_In_Number_Overlaps()
+        {
+            // assemble
+
+            var recommendations = new List<EntityRecommendation>
+            {
+                new EntityRecommendation { Type = "foo", Entity = "3", StartIndex=12, EndIndex=12},
+                new EntityRecommendation { Type = "builtin.number", Entity = "3", StartIndex=12, EndIndex=12}
+            };
+
+            var result = new LuisResult("total miles 3", recommendations);
+
+            // act
+
+            EntityRecommendation recommendation;
+            result.TryFindEntity("builtin.number", out recommendation);
+            EntityRecommendation recommendationFoo;
+            result.TryFindEntity("foo", out recommendationFoo);
+
+            // assert
+            Assert.IsNotNull(recommendation, "builtin.number entity recommendation not found");
+            Assert.AreEqual("3", recommendation.Entity, "wrong builtin.number entity recommendation selected");
+
+            Assert.IsNotNull(recommendationFoo, "foo entity recommendation not found");
+            Assert.AreEqual("3", recommendationFoo.Entity, "wrong foo entity recommendation selected");
+        }
 
         [TestMethod]
         public void Luis_TryFindEntity_Date_And_Multiple_Numbers_Where_One_Number_Overlaps()


### PR DESCRIPTION
Addresses https://github.com/Microsoft/BotBuilder-V3/issues/45