### PR TITLE
Use entire serviceUrl in TrustServiceUrl

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/SkillBotAuthentication.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/SkillBotAuthentication.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Connector.SkillAuthentication
                         {
                             var claimsIdentity = await JwtTokenValidation.AuthenticateRequest(activity, authorizationHeader.ToString(), credentialProvider, authConfiguration, _httpClient).ConfigureAwait(false);
                             // this is done in JwtTokenValidation.AuthenticateRequest, but the oauthScope is not set so we update it here
-                            MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl, oauthScope: JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims));
+                            MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl, oauthScope: JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims), conversationId: activity.Conversation.Id);
                         }
                     }
                     catch (UnauthorizedAccessException)

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/SkillBotAuthentication.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/SkillBotAuthentication.cs
@@ -18,13 +18,6 @@ namespace Microsoft.Bot.Connector.SkillAuthentication
         /// </summary>
         public Type AuthenticationConfigurationProviderType { get; set; }
 
-        /// <summary>
-        /// Used for environments where multiple parent bots are hosted at the same base url.
-        /// Setting this to 'true' will extend the trusted serviceurl beyond Host, and up to
-        /// '/v3/conversations'.
-        /// </summary>
-        public bool ExtendTrustServiceUrlHost { get; set; } = false;
-
         private static HttpClient _httpClient = new HttpClient();
 
         public override async Task OnActionExecutingAsync(HttpActionContext actionContext, CancellationToken cancellationToken)
@@ -43,14 +36,9 @@ namespace Microsoft.Bot.Connector.SkillAuthentication
                         foreach (var activity in activities)
                         {
                             var claimsIdentity = await JwtTokenValidation.AuthenticateRequest(activity, authorizationHeader.ToString(), credentialProvider, authConfiguration, _httpClient).ConfigureAwait(false);
-                            // this is done in JwtTokenValidation.AuthenticateRequest, but the oauthScope is not set so we update it here
-                            string extendedHost = null;
-                            if (ExtendTrustServiceUrlHost)
-                            {
-                                extendedHost = activity.ServiceUrl;
-                            }
-
-                            MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl, oauthScope: JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims), extendedHost: extendedHost);
+                            
+                            // Trusting of the servcieUrl is done in JwtTokenValidation.AuthenticateRequest, but the oauthScope is not set so we update it here
+                            MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl, oauthScope: JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims));
                         }
                     }
                     catch (UnauthorizedAccessException)

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/SkillBotAuthentication.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/SkillBotAuthentication.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Bot.Connector.SkillAuthentication
                         {
                             var claimsIdentity = await JwtTokenValidation.AuthenticateRequest(activity, authorizationHeader.ToString(), credentialProvider, authConfiguration, _httpClient).ConfigureAwait(false);
                             // this is done in JwtTokenValidation.AuthenticateRequest, but the oauthScope is not set so we update it here
-                            MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl, oauthScope: JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims), conversationId: activity.Conversation.Id);
+                            MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl, oauthScope: JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims));
                         }
                     }
                     catch (UnauthorizedAccessException)

--- a/CSharp/Library/Microsoft.Bot.Connector.NetFramework/SkillBotAuthentication.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.NetFramework/SkillBotAuthentication.cs
@@ -47,8 +47,7 @@ namespace Microsoft.Bot.Connector.SkillAuthentication
                             string extendedHost = null;
                             if (ExtendTrustServiceUrlHost)
                             {
-                                var conversationsIndex = activity.ServiceUrl.IndexOf("/v3/conversations");
-                                extendedHost = activity.ServiceUrl.Substring(0, conversationsIndex);
+                                extendedHost = activity.ServiceUrl;
                             }
 
                             MicrosoftAppCredentials.TrustServiceUrl(activity.ServiceUrl, oauthScope: JwtTokenValidation.GetAppIdFromClaims(claimsIdentity.Claims), extendedHost: extendedHost);

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
@@ -260,19 +260,25 @@ namespace Microsoft.Bot.Connector
                 }
             }
 
-            var endOfBaseUrl = uri.AbsoluteUri.IndexOf("v3/conversations", StringComparison.OrdinalIgnoreCase);
-            if (endOfBaseUrl > 0)
+            // Iterate known protocol url pieces, and look for a valid ServiceUrl derived from AbsoluteURl parsed.
+            foreach(var v3ProtocolUrl in new[] { "v3/conversations", "v3/attachments", "api/usertoken", "api/botsignin", "v3/botstate"})
             {
-                var serviceUrl = uri.AbsoluteUri.Substring(0, endOfBaseUrl);
-                if (TrustedHostNames.TryGetValue(serviceUrl, out trustedHostInfo))
+                var endofV3UrlBase = uri.AbsoluteUri.IndexOf(v3ProtocolUrl, StringComparison.OrdinalIgnoreCase);
+                if (endofV3UrlBase > 0)
                 {
-                    // check if the trusted service url is still valid
-                    if (trustedHostInfo.DateTime > DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(5)))
+                    var serviceUrl = uri.AbsoluteUri.Substring(0, endofV3UrlBase);
+                    if (TrustedHostNames.TryGetValue(serviceUrl, out trustedHostInfo))
                     {
-                        return trustedHostInfo;
+                        // check if the trusted service url is still valid
+                        if (trustedHostInfo.DateTime > DateTime.UtcNow.Subtract(TimeSpan.FromMinutes(5)))
+                        {
+                            return trustedHostInfo;
+                        }
                     }
-                }
 
+                    // The correct protocol was identified, but the url is not trusted.
+                    return null;
+                }
             }
 
             return null;

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
@@ -147,7 +147,12 @@ namespace Microsoft.Bot.Connector
                     // by default the service url is valid for one day
                     setExpirationTime = DateTime.UtcNow.Add(TimeSpan.FromDays(1));
                 }
-                
+
+                if (!serviceUrl.EndsWith("/"))
+                {
+                    serviceUrl += "/";
+                }
+
                 TrustedHostNames.AddOrUpdate(serviceUrl,
                                             new TrustedHostInfo
                                             {
@@ -191,21 +196,6 @@ namespace Microsoft.Bot.Connector
             {
                 return TrustedUri(uri);
             }
-            return false;
-        }
-
-        private bool ShouldSetToken(HttpRequestMessage request)
-        {
-            if (TrustedUri(request.RequestUri))
-            {
-                return true;
-            }
-
-#if NET45
-            Trace.TraceWarning($"Service url {request.RequestUri.Authority} is not trusted and JwtToken cannot be sent to it.");
-#else
-            logger?.LogWarning($"Service url {request.RequestUri.Authority} is not trusted and JwtToken cannot be sent to it.");
-#endif
             return false;
         }
 

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Bot.Connector
                 }
             }
 
-            var endOfBaseUrl = uri.AbsoluteUri.IndexOf("v3/conversations", StringComparison.InvariantCultureIgnoreCase);
+            var endOfBaseUrl = uri.AbsoluteUri.IndexOf("v3/conversations", StringComparison.OrdinalIgnoreCase);
             if (endOfBaseUrl > 0)
             {
                 var serviceUrl = uri.AbsoluteUri.Substring(0, endOfBaseUrl);

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Bot.Connector
                             string requestUriPath = request.RequestUri.AbsolutePath;
                             foreach(var scope in scopes)
                             {
-                                if (!string.IsNullOrEmpty(scope.Value) && requestUriPath.Contains(scope.Value))
+                                if (requestUriPath.Contains(scope.Value))
                                 {
                                     oauthScope = scope.Key;
                                     break;

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
@@ -233,10 +233,10 @@ namespace Microsoft.Bot.Connector
                 if (TrustedHostNames.TryGetValue(request.RequestUri.Host, out trustedHostInfo))
                 {
                     // Some parent bot hosting environments have the same baseurl for multiple parent bots 
-                    // and must be routed with the conversation.id in the ServiceUrl of the activity being sent.
+                    // and must be routed with an extended url.
 
                     // This code determines the correct parent bot id, or OAuthScope, by checking known scopes
-                    // for the one containing the conversation.id.
+                    // for the one containing the extended path comparison.
                     var scopes = trustedHostInfo.OAuthScopes;
                     if (scopes.Count > 0)
                     {

--- a/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
+++ b/CSharp/Library/Microsoft.Bot.Connector.Shared/MicrosoftAppCredentials.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Bot.Connector
                             string requestUriPath = request.RequestUri.AbsolutePath;
                             foreach(var scope in scopes)
                             {
-                                if (requestUriPath.Contains(scope.Value))
+                                if (!string.IsNullOrEmpty(scope.Value) && requestUriPath.Contains(scope.Value))
                                 {
                                     oauthScope = scope.Key;
                                     break;

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/GetTokenRefreshTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/GetTokenRefreshTests.cs
@@ -6,6 +6,10 @@ using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.Bot.Connector;
 using System.Threading.Tasks;
+using System.Net.Http;
+using System.Threading;
+using System.Linq;
+using System.Runtime.Remoting.Messaging;
 
 namespace Microsoft.Bot.Builder.Tests
 {
@@ -32,14 +36,57 @@ namespace Microsoft.Bot.Builder.Tests
 
         public class TestMicrosoftAppCredentials : MicrosoftAppCredentials
         {
+            public HttpRequestMessage RequestMessage { get; set; }
+
             public TestMicrosoftAppCredentials(string appId, string appPassword)
                 : base(appId, appPassword)
             {
             }
 
-            public KeyValuePair<string, ICollection<string>> GetServiceUrlsAndScopes(string host)
+            public Dictionary<string, string> GetTrustedUrls()
             {
-                return new KeyValuePair<string, ICollection<string>>(host, TrustedHostNames[host].OAuthScopes.Keys);
+                return TrustedHostNames.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value.OAuthScope))
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+            }
+
+            public override async Task ProcessHttpRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                await base.ProcessHttpRequestAsync(request, cancellationToken).ConfigureAwait(false);
+                RequestMessage = request;
+
+                // stop the flow (test looks for this exception)
+                throw new Exception("ignore");
+            }
+        }
+
+        [TestMethod]
+        public async Task TokenTest_OAuthScope()
+        {
+            string host = "testurl.com";
+            string baseUrl = $"http://{host}/morehere/extended/";
+            
+            var credentials = new TestMicrosoftAppCredentials("a40e1db0-b7a2-4e6e-af0e-b4987f73228f", "sbF0902^}tyvpvEDXTMX9^|");
+            MicrosoftAppCredentials.TrustServiceUrl(baseUrl, oauthScope: "3851a47b-53ed-4d29-b878-6e941da61e98");
+
+            var connectorClient = new ConnectorClient(new Uri(baseUrl), credentials, addJwtTokenRefresher: false);
+            var activity = new Activity() { Type = ActivityTypes.Message, Text = "test" };
+
+            try
+            {
+                var response = connectorClient.Conversations.SendToConversation("testConversationId", activity);
+            } 
+            catch (Exception ex)
+            {
+                if (!ex.Message.Equals("ignore", StringComparison.InvariantCultureIgnoreCase)) 
+                {
+                    Assert.Fail("Test did not throw 'ignore' exception as expected");
+                }
+
+                var oauthScope = "3851a47b-53ed-4d29-b878-6e941da61e98";
+                var authResult = await credentials.GetTokenAsync(oauthScope: oauthScope).ConfigureAwait(false);
+                var credentialsHeader = credentials.RequestMessage.Headers.Authorization.ToString();
+
+                Assert.AreEqual("Bearer " + authResult, credentialsHeader);
             }
         }
 
@@ -48,18 +95,25 @@ namespace Microsoft.Bot.Builder.Tests
         {
             string host = "testurl.com";
             string baseUrl = $"http://{host}/";
+            string baseUrlExtended = "extended/url/";
+            string baseUrlExtended2 = "extended2/url/";
             string scope1 = "testscope1";
             string scope2 = "testscope2";
 
+            var url1 = $"{baseUrl}{baseUrlExtended}";
+            var url2 = $"{baseUrl}{baseUrlExtended2}";
+            var url3 = $"http://www.SomeOtherBaseUrl.com/";
             // Add the first path twice (to ensure duplicates are not added)
-            MicrosoftAppCredentials.TrustServiceUrl($"{baseUrl}{scope2}", DateTime.Now.AddDays(1), scope2);
-            MicrosoftAppCredentials.TrustServiceUrl($"{baseUrl}{scope2}", DateTime.Now.AddDays(1), scope2);
-            MicrosoftAppCredentials.TrustServiceUrl($"{baseUrl}{scope1}", DateTime.Now.AddDays(1), scope1);
-            MicrosoftAppCredentials.TrustServiceUrl($"SomeOtherBaseUrl/{scope1}", DateTime.Now.AddDays(1), scope1);
+            MicrosoftAppCredentials.TrustServiceUrl(url1, DateTime.Now.AddDays(1), scope1);
+            MicrosoftAppCredentials.TrustServiceUrl(url1, DateTime.Now.AddDays(1), scope1);
+            MicrosoftAppCredentials.TrustServiceUrl(url2, DateTime.Now.AddDays(1), scope2);
+            MicrosoftAppCredentials.TrustServiceUrl(url3, DateTime.Now.AddDays(1), scope2);
 
-            var scopes = new TestMicrosoftAppCredentials(string.Empty, string.Empty).GetServiceUrlsAndScopes(host);
+            var scopes = new TestMicrosoftAppCredentials(string.Empty, string.Empty).GetTrustedUrls();
 
-            Assert.AreEqual(2, scopes.Value.Count);
+            Assert.IsTrue(scopes[url1] == scope1, $"{url1} missing expected {scope1}");
+            Assert.IsTrue(scopes[url2] == scope2, $"{url2} missing expected {scope2}");
+            Assert.IsTrue(scopes[url3] == scope2, $"{url3} missing expected {scope2}");
         }
         
         [TestMethod]
@@ -67,17 +121,25 @@ namespace Microsoft.Bot.Builder.Tests
         {
             string host = "testurl.com";
             string baseUrl = $"http://{host}/";
+            string baseUrlExtended = "extended/url/";
+            string baseUrlExtended2 = "extended2/url/";
             string scope1 = "testscope1";
             string scope2 = "testscope2";
+
+            var url1 = $"{baseUrl}{baseUrlExtended}";
+            var url2 = $"{baseUrl}{baseUrlExtended2}";
+            var url3 = $"http://www.SomeOtherBaseUrl.com/";
             // Add the first path twice (to ensure duplicates are not added)
-            MicrosoftAppCredentials.TrustServiceUrl($"{baseUrl}{scope2}", oauthScope: scope2);
-            MicrosoftAppCredentials.TrustServiceUrl($"{baseUrl}{scope2}", oauthScope: scope2);
-            MicrosoftAppCredentials.TrustServiceUrl($"{baseUrl}{scope1}", oauthScope: scope1);
-            MicrosoftAppCredentials.TrustServiceUrl($"SomeOtherBaseUrl/{scope1}", oauthScope: scope1);
+            MicrosoftAppCredentials.TrustServiceUrl(url1, oauthScope: scope1);
+            MicrosoftAppCredentials.TrustServiceUrl(url1, oauthScope: scope1);
+            MicrosoftAppCredentials.TrustServiceUrl(url2, oauthScope: scope2);
+            MicrosoftAppCredentials.TrustServiceUrl(url3, oauthScope: scope2);
 
-            var scopes = new TestMicrosoftAppCredentials(string.Empty, string.Empty).GetServiceUrlsAndScopes(host);
+            var scopes = new TestMicrosoftAppCredentials(string.Empty, string.Empty).GetTrustedUrls();
 
-            Assert.AreEqual(2, scopes.Value.Count);
+            Assert.IsTrue(scopes[url1] == scope1, $"{url1} missing expected {scope1}");
+            Assert.IsTrue(scopes[url2] == scope2, $"{url2} missing expected {scope2}");
+            Assert.IsTrue(scopes[url3] == scope2, $"{url3} missing expected {scope2}");
         }
 
         [TestMethod]

--- a/CSharp/Tests/Microsoft.Bot.Builder.Tests/GetTokenRefreshTests.cs
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Tests/GetTokenRefreshTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Bot.Builder.Tests
             } 
             catch (Exception ex)
             {
-                if (!ex.Message.Equals("ignore", StringComparison.InvariantCultureIgnoreCase)) 
+                if (!ex.Message.Equals("ignore", StringComparison.OrdinalIgnoreCase)) 
                 {
                     Assert.Fail("Test did not throw 'ignore' exception as expected");
                 }


### PR DESCRIPTION
This enables parent bot hosting environments where multiple bots are hosted at the same baseUrl.